### PR TITLE
Fix video writing thread termination issue

### DIFF
--- a/inference_video.py
+++ b/inference_video.py
@@ -277,6 +277,9 @@ if args.montage:
     write_buffer.put(np.concatenate((lastframe, lastframe), 1))
 else:
     write_buffer.put(lastframe)
+
+write_buffer.put(frame)
+
 import time
 while(not write_buffer.empty()):
     time.sleep(0.1)


### PR DESCRIPTION
If a `None` is not added to the `write_buffer`, the write thread will continue running indefinitely.