### PR TITLE
Fix NumPy Deprecation Issues in scikit-video

### DIFF
--- a/Colab_demo.ipynb
+++ b/Colab_demo.ipynb
@@ -45,7 +45,7 @@
       "source": [
         "%cd /content/arXiv2020-RIFE/\n",
         "!gdown --id 1i3xlKb7ax7Y70khcTcuePi6E7crO_dFc\n",
-        "!pip install scikit-video"
+        "!pip install git+https://github.com/rk-exxec/scikit-video.git@numpy_deprecation"
       ]
     },
     {


### PR DESCRIPTION
To resolve issue #388 , instead of using:  

```sh
!pip install scikit-video
```

I installed the **patched version of scikit-video** from the following GitHub branch:  

```sh
!pip install git+https://github.com/rk-exxec/scikit-video.git@numpy_deprecation
```

This **fixes the NumPy deprecation issues** by replacing deprecated NumPy aliases (`np.float`, `np.int`, etc.) with their correct equivalents.

---

## Impact of This Fix  

✔ **Ensures compatibility with modern NumPy versions (1.20+)**  
✔ **Eliminates deprecation warnings**  
✔ **Avoids the need for downgrading NumPy, which currently fails**  
✔ **Improves package stability and usability in environments like Google Colab**  

---